### PR TITLE
Pin Intel compiler version in CI

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -155,7 +155,7 @@ jobs:
           mv /tmp/oneAPI.repo /etc/yum.repos.d
       - name: General update
         run: yum -y makecache
-      - run: yum install -y environment-modules intel-oneapi-compiler-dpcpp-cpp
+      - run: yum install -y environment-modules intel-oneapi-compiler-dpcpp-cpp-2023.1.0
       - run: /opt/intel/oneapi/modulefiles-setup.sh
       - name: Build
         shell: bash


### PR DESCRIPTION
Previously CI would install the latest Intel OneAPI compilers which left us susceptible to breaking changes to Intel's compiler packages. This PR simply pins the version to 2023.1.0.