### PR TITLE
clang-tidy: add checks/format to test exec

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,5 @@
+---
+Checks:          'clang-diagnostic-*,clang-analyzer-*,-clang-analyzer-security.insecureAPI.strcpy,-clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling'
+WarningsAsErrors: ''
+HeaderFilterRegex: ''
+AnalyzeTemporaryDtors: false

--- a/Build/test/Makefile
+++ b/Build/test/Makefile
@@ -16,7 +16,8 @@ bin = .
 
 # Definition of the object variables
 
-obj =    main.o
+srcs =    main.c
+obj = $(srcs:.c=.o)
 objwin = $(obj:.o=.obj)
 
 #*** General Purpose Rules ***
@@ -60,6 +61,13 @@ gnu_linux_64 : exe       = test_linux_64
 
 gnu_linux_64: $(obj)
 	$(CC) -m64 -o $(bin)/$(exe) $(obj)
+
+gnu_linux_64_check : CFLAGS    = -O2 -m64 -Wall
+gnu_linux_64_check: $(srcs)
+	clang-tidy $^ --  $(CFLAGS) $(INC)
+
+gnu_linux_64_format: $(srcs)
+	clang-format -i $^
 
 # ------------- intel linux 64 ----------------
 

--- a/Build/test/gnu_linux_64/check_test.sh
+++ b/Build/test/gnu_linux_64/check_test.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+make -f ../Makefile gnu_linux_64_check

--- a/Build/test/gnu_linux_64/format_test.sh
+++ b/Build/test/gnu_linux_64/format_test.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+make -f ../Makefile gnu_linux_64_format

--- a/Source/test/main.c
+++ b/Source/test/main.c
@@ -1,7 +1,40 @@
+#include <stdint.h>
 #include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+struct example {
+  uint64_t i1;
+  uint8_t b1;
+  uint64_t i2;
+  uint8_t b2;
+  uint64_t i3;
+  uint8_t b3;
+    uint64_t i4;
+  uint8_t b4;
+  uint64_t i5;
+  uint8_t b5;
+  uint64_t i6;
+  uint8_t b6;
+  uint64_t i7;
+  uint8_t b7;
+  uint64_t i8;
+  uint8_t b8;
+};
 
 /* ------------------ main ------------------------ */
 
-int main(int argc, char **argv){
-  printf("test\n");
+int main(int argc, char **argv)
+
+{
+  // Warning: i is not modified so this is an endless loop. Not a compiler error
+  // but almost certainly not what we want, hence a clang-tidy warning.
+  for (int i = 0; i < 30;) {
+    printf("i: %d",i);
+  }
+  // (Potential) Warning: by default clang-tidy warns against strcat, but this
+  // is disabled in the ".clang-tidy" file as it's pervasive in smokeview and
+  // would generate a lot of noise.
+  char buf[256];
+    strcat(buf, "some string");
 }


### PR DESCRIPTION
Hi Glenn,

Here is the test executable with a couple of examples added. I've tried to add warnings that wouldn't be caught be gcc.

This includes both linting and formatting. The key difficulty is still the Makefile style, we need to list source files, not just object files.