### PR TITLE
add configuration to clang_tidy_file

### DIFF
--- a/Utilities/Scripts/clang_tidy_file.sh
+++ b/Utilities/Scripts/clang_tidy_file.sh
@@ -10,4 +10,4 @@ base_dir="$(realpath "$script_dir/../..")"
 source_dir="$(realpath "$base_dir/Source")"
 # The absoulte path to the directory of the file we're analysing
 file_dir="$(dirname "$file")"
-clang-tidy "$file" -- -I"$source_dir"/shared -I"$file_dir" -I"$source_dir"/glew -I"$source_dir"/glut_gl -I"$source_dir"/pthreads -I"$source_dir"/zlib128 --config-file="$base_dir"/.clang-tidy -D_CRT_SECURE_NO_WARNINGS >& "$outfile"
+clang-tidy "$file" --config-file="$base_dir"/.clang-tidy -- -I"$source_dir"/shared -I"$file_dir" -I"$source_dir"/glew -I"$source_dir"/glut_gl -I"$source_dir"/pthreads -I"$source_dir"/zlib128 -D_CRT_SECURE_NO_WARNINGS >& "$outfile"

--- a/Utilities/Scripts/clang_tidy_file.sh
+++ b/Utilities/Scripts/clang_tidy_file.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 file=$1
 outfile=$file.out
-
-clang-tidy $file -- -I../shared -I. -I../glew >& $outfile
+# The absolute path to the directoy of this script
+script_dir="$(dirname "$(realpath $0)")"
+# The absolute path to base of the repo
+base_dir="$(realpath "$script_dir/../..")"
+# The absolute path to the Source directory. Include paths are made relative to
+# this
+source_dir="$(realpath "$base_dir/Source")"
+# The absoulte path to the directory of the file we're analysing
+file_dir="$(dirname "$file")"
+clang-tidy "$file" -- -I"$source_dir"/shared -I"$file_dir" -I"$source_dir"/glew -I"$source_dir"/glut_gl -I"$source_dir"/pthreads -I"$source_dir"/zlib128 --config-file="$base_dir"/.clang-tidy -D_CRT_SECURE_NO_WARNINGS >& "$outfile"

--- a/Utilities/Scripts/clang_tidy_file.sh
+++ b/Utilities/Scripts/clang_tidy_file.sh
@@ -10,4 +10,4 @@ base_dir="$(realpath "$script_dir/../..")"
 source_dir="$(realpath "$base_dir/Source")"
 # The absoulte path to the directory of the file we're analysing
 file_dir="$(dirname "$file")"
-clang-tidy "$file" --config-file="$base_dir"/.clang-tidy -- -I"$source_dir"/shared -I"$file_dir" -I"$source_dir"/glew -I"$source_dir"/glut_gl -I"$source_dir"/pthreads -I"$source_dir"/zlib128 -D_CRT_SECURE_NO_WARNINGS >& "$outfile"
+clang-tidy "$file" --config-file="$base_dir"/.clang-tidy -- -I"$source_dir"/shared -I"$file_dir" -I"$source_dir"/glew -I"$source_dir"/glut_gl -I"$source_dir"/pthreads -I"$source_dir"/zlib128 -I"$source_dir"/gd-2.0.15 -D_CRT_SECURE_NO_WARNINGS >& "$outfile"

--- a/Utilities/Scripts/clang_tidy_file.sh
+++ b/Utilities/Scripts/clang_tidy_file.sh
@@ -10,4 +10,4 @@ base_dir="$(realpath "$script_dir/../..")"
 source_dir="$(realpath "$base_dir/Source")"
 # The absoulte path to the directory of the file we're analysing
 file_dir="$(dirname "$file")"
-clang-tidy "$file" --config-file="$base_dir"/.clang-tidy -- -I"$source_dir"/shared -I"$file_dir" -I"$source_dir"/glew -I"$source_dir"/glut_gl -I"$source_dir"/pthreads -I"$source_dir"/zlib128 -I"$source_dir"/gd-2.0.15 -D_CRT_SECURE_NO_WARNINGS >& "$outfile"
+clang-tidy "$file" --config-file="$base_dir"/.clang-tidy -- -I"$source_dir"/shared -I"$file_dir" -I"$source_dir"/glew -I"$source_dir"/glut_gl -I"$source_dir"/pthreads -I"$source_dir"/zlib128 -I"$source_dir"/gd-2.0.15 -D_CRT_SECURE_NO_WARNINGS -Dpp_LUA >& "$outfile"


### PR DESCRIPTION
- Adds includes for platforms that don't have libraries (e.g. pthreads, zlib) installed. Particularly necessary on Windows.
- Uses the `.clang-tidy` file as config.
- Calculates absolute paths so it can be used from anywhere.