### PR TITLE
clang-tidy: add checks for formatting

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,2 +1,4 @@
-BreakBeforeBraces: Attach
 AllowShortIfStatementsOnASingleLine: WithoutElse
+BreakBeforeBraces: Custom
+BraceWrapping:
+  BeforeElse: true

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,5 +1,9 @@
 ---
-Checks:          'clang-diagnostic-*,clang-analyzer-*,-clang-analyzer-security.insecureAPI.strcpy,-clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling'
-WarningsAsErrors: ''
-HeaderFilterRegex: ''
+Checks: "clang-diagnostic-*,clang-analyzer-*,-clang-analyzer-security.insecureAPI.strcpy,-clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling,readability-identifier-naming"
+WarningsAsErrors: ""
+HeaderFilterRegex: ""
 AnalyzeTemporaryDtors: false
+CheckOptions:
+  - { key: readability-identifier-naming.FunctionCase, value: CamelCase }
+  - { key: readability-identifier-naming.VariableCase, value: lower_case }
+  - { key: readability-identifier-naming.GlobalConstantCase, value: UPPER_CASE }


### PR DESCRIPTION
A lot of the concepts you've written about in https://github.com/firemodels/smv/pull/1696#issuecomment-1734210502 we can put into clang-tidy and clang-format.

- [x] (clang-format) If-else braces on next line
- [ ] If-else no space before brace (not sure if this is possible)
- [x] (clang-tidy) Function names in CamelCase
- [x] (clang-tidy) Variable names in snake_case
- [x] (clang-tidy) Upper case global DEFINEs 
- [ ] data/info struct naming. Doubt this could be linted.

I have made PRs removing global variables but ditched them as it touched too many files (which I guess is kind of the point). Would still be a good goal to reduce them.

Items marked (clang-format) are those that have not semantic affect on the code. Those marked (clang-tidy) have a semantic impact (e.g. changing names).